### PR TITLE
fix: handle PermissionError when running container with custom UID

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -149,7 +149,6 @@ WORKDIR /app
 COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
 COPY deploy/docker/security_config.yaml ./security_config.yaml
-
 # Copy wheels from builder and install
 COPY --from=builder /wheels /wheels
 RUN pip install --no-cache-dir --no-index --find-links=/wheels k8s-mcp-server && \
@@ -158,7 +157,8 @@ RUN pip install --no-cache-dir --no-index --find-links=/wheels k8s-mcp-server &&
 # Set ownership after all files have been copied
 RUN chown -R appuser:appgroup /app \
     && chown -R appuser:appgroup /home/appuser \
-    && chmod -R o-rwx /app /home/appuser
+    && chmod -R o-rwx /app /home/appuser \
+    && chmod 644 /app/security_config.yaml
 
 # Switch to non-root user
 USER appuser

--- a/src/k8s_mcp_server/security.py
+++ b/src/k8s_mcp_server/security.py
@@ -124,7 +124,12 @@ def load_security_config() -> SecurityConfig:
 
     if SECURITY_CONFIG_PATH:
         config_path = Path(SECURITY_CONFIG_PATH)
-        if config_path.exists():
+        try:
+            config_exists = config_path.exists()
+        except PermissionError:
+            logger.warning(f"Permission denied checking security config at {config_path}")
+            config_exists = False
+        if config_exists:
             try:
                 with open(config_path) as f:
                     config_data = yaml.safe_load(f)


### PR DESCRIPTION
## Problem

When running the Docker container with a custom user ID to match host kubeconfig permissions (e.g., `-u 1000:1000`), the server crashes with `PermissionError` at startup because `Path.exists()` on `/app/security_config.yaml` fails — the file is owned by `appuser` (UID 10001) and has no world-readable permissions.

Reported in #5.

## Changes

### `src/k8s_mcp_server/security.py`
- Wrap `config_path.exists()` in `try/except PermissionError` — server gracefully falls back to defaults instead of crashing

### `deploy/docker/Dockerfile`  
- Make `security_config.yaml` world-readable (`chmod 644`) after the `chmod -R o-rwx` step, since it contains no secrets (just command validation rules)

Fixes #5