### PR TITLE
fix: reload_security_config() now updates SECURITY_MODE from environment

### DIFF
--- a/src/k8s_mcp_server/security.py
+++ b/src/k8s_mcp_server/security.py
@@ -6,6 +6,7 @@ and pipe command validation.
 """
 
 import logging
+import os
 import re
 import shlex
 from dataclasses import dataclass
@@ -331,13 +332,15 @@ def validate_pipe_command(pipe_command: str) -> None:
 
 
 def reload_security_config() -> None:
-    """Reload security configuration from file.
+    """Reload security configuration from file and re-read security mode from environment.
 
     This allows for dynamic reloading of security rules without restarting the server.
+    Call this after changing K8S_MCP_SECURITY_MODE or K8S_MCP_SECURITY_CONFIG environment variables.
     """
-    global SECURITY_CONFIG
+    global SECURITY_CONFIG, SECURITY_MODE
     SECURITY_CONFIG = load_security_config()
-    logger.info("Security configuration reloaded")
+    SECURITY_MODE = os.environ.get("K8S_MCP_SECURITY_MODE", "strict")
+    logger.info(f"Security configuration reloaded (mode: {SECURITY_MODE})")
 
 
 def validate_command(command: str) -> None:


### PR DESCRIPTION
## Bug

`test_security_permissive_mode` was failing because switching to permissive mode at runtime had no effect.

### Root cause

`security.py` does:
```python
from k8s_mcp_server.config import SECURITY_MODE  # imports string value, not a live reference
```

`reload_security_config()` updated `SECURITY_CONFIG` but not `SECURITY_MODE`, so even after:
```python
monkeypatch.setenv("K8S_MCP_SECURITY_MODE", "permissive")
reload_security_config()
```
...the module-level `SECURITY_MODE` string was still `"strict"`, and `validate_k8s_command()` kept blocking commands.

### Fix

```python
def reload_security_config() -> None:
    global SECURITY_CONFIG, SECURITY_MODE
    SECURITY_CONFIG = load_security_config()
    SECURITY_MODE = os.environ.get("K8S_MCP_SECURITY_MODE", "strict")  # ← new
```

One-line fix: re-read the env var and update the module-level variable on every reload.

---
*🤖 Automated response by Marvin • [alexei-led](https://github.com/alexei-led)*