### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Claude can help users by:
 - Suggesting optimizations
 - Crafting Kubernetes manifests
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/alexei-led-k8s-mcp-server).
+
 ## Quick Start with Claude Desktop
 
 Get Claude helping with your Kubernetes clusters in under 2 minutes:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/alexei-led-k8s-mcp-server)